### PR TITLE
Quiet mode implementation

### DIFF
--- a/fvupdater.cpp
+++ b/fvupdater.cpp
@@ -153,15 +153,11 @@ void FvUpdater::showUpdateConfirmationDialogUpdatedWithCurrentUpdateProposal()
         //Get the proposed update and emit the signal
         FvAvailableUpdate* proposedUpdate = FvUpdater::sharedUpdater()->GetProposedUpdate();
         if (! proposedUpdate) {
-            qDebug() << "FvUpdater::showUpdaterWindowUpdatedWithCurrentUpdateProposal(): proposedUpdate is empty!";
+            qDebug() << "FvUpdater::showUpdateConfirmationDialogUpdatedWithCurrentUpdateProposal(): proposedUpdate is empty!";
             return;
         }
 
-        emit proposedUpdateChanged(proposedUpdate);
-        // QString downloadLinkString = m_ui->updateFileLinkLabel->text()
-        //         .arg(proposedUpdate->GetEnclosureUrl().toString());
-        // m_ui->updateFileLinkLabel->setText(downloadLinkString);
-
+        emit updateDownloadLinkReady(proposedUpdate->GetEnclosureUrl().toString());
     }
 }
 
@@ -226,7 +222,6 @@ FvAvailableUpdate* FvUpdater::GetProposedUpdate()
     return m_proposedUpdate;
 }
 
-
 void FvUpdater::InstallUpdate()
 {
     qDebug() << "Install update";
@@ -234,8 +229,10 @@ void FvUpdater::InstallUpdate()
     // Check callback function
     if (check_callback) {
         if (!check_callback(check_context, (void*)m_updaterWindow)) {
-            hideUpdaterWindow();
-            hideUpdateConfirmationDialog(); // if any; shouldn't be shown at this point, but who knows
+            if(m_mode == NORMAL) {
+                hideUpdaterWindow();
+                hideUpdateConfirmationDialog(); // if any; shouldn't be shown at this point, but who knows
+            }
             return;
         }
     }
@@ -255,17 +252,19 @@ void FvUpdater::SkipUpdate()
 
     // Start ignoring this particular version
     FVIgnoredVersions::IgnoreVersion(proposedUpdate->GetEnclosureVersion());
-
-    hideUpdaterWindow();
-    hideUpdateConfirmationDialog();    // if any; shouldn't be shown at this point, but who knows
+    if(m_mode == NORMAL) {
+        hideUpdaterWindow();
+        hideUpdateConfirmationDialog();    // if any; shouldn't be shown at this point, but who knows
+    }
 }
 
 void FvUpdater::RemindMeLater()
 {
     qDebug() << "Remind me later";
-
-    hideUpdaterWindow();
-    hideUpdateConfirmationDialog();    // if any; shouldn't be shown at this point, but who knows
+    if(m_mode == NORMAL) {
+        hideUpdaterWindow();
+        hideUpdateConfirmationDialog();    // if any; shouldn't be shown at this point, but who knows
+    }
 }
 
 void FvUpdater::UpdateInstallationConfirmed()

--- a/fvupdater.h
+++ b/fvupdater.h
@@ -48,10 +48,16 @@ public slots:
     bool CheckForUpdatesSilent();
     bool CheckForUpdatesNotSilent();
 
+    // Update window button slots
+    void InstallUpdate();
+    void SkipUpdate();
+    void RemindMeLater();
+
 signals:
     // This signal will inform, whether network is accessible or not
     void updatesDownloaded(bool success);
     void proposedUpdateChanged(FvAvailableUpdate* proposedUpdate);
+    void updateDownloadLinkReady(QString link);
 
 
     //
@@ -75,11 +81,6 @@ protected:
 
 
 protected slots:
-
-    // Update window button slots
-    void InstallUpdate();
-    void SkipUpdate();
-    void RemindMeLater();
 
     // Update confirmation dialog button slots
     void UpdateInstallationConfirmed();

--- a/fvupdater.h
+++ b/fvupdater.h
@@ -13,6 +13,10 @@ class FvAvailableUpdate;
 
 typedef int (*check_before_update_callback)(void *, void *);
 
+enum FERVOR_MODE {
+    QUIET,
+    NORMAL
+};
 
 class FvUpdater : public QObject
 {
@@ -23,7 +27,6 @@ public:
     // Singleton
     static FvUpdater* sharedUpdater();
     static void drop();
-
     // Set / get feed URL
     void SetFeedURL(QUrl feedURL);
     void SetFeedURL(QString feedURL);
@@ -34,6 +37,7 @@ public:
     QString GetDynamicUrlContent();
 
     void SetCheckBeforeUpdate(check_before_update_callback callback, void* context);
+    void SetFervorMode(FERVOR_MODE mode);
 
 public slots:
 
@@ -47,6 +51,7 @@ public slots:
 signals:
     // This signal will inform, whether network is accessible or not
     void updatesDownloaded(bool success);
+    void proposedUpdateChanged(FvAvailableUpdate* proposedUpdate);
 
 
     //
@@ -94,6 +99,10 @@ private:
 
     static FvUpdater* m_Instance;           // Singleton instance
 
+    //Mode of Fervor operation
+    //QUIET - use signals to communicate with the application
+    //NORMAL - use default QWidget windows
+    FERVOR_MODE m_mode;
 
     //
     // Windows / dialogs

--- a/fvupdater.h
+++ b/fvupdater.h
@@ -56,7 +56,6 @@ public slots:
 signals:
     // This signal will inform, whether network is accessible or not
     void updatesDownloaded(bool success);
-    // void proposedUpdateChanged(FvAvailableUpdate* proposedUpdate);
     void proposedVersionChanged(QString version);
     void proposedReleaseNotesChanged(QString content);
     void proposedReleaseNotesLinkChanged(QUrl link);

--- a/fvupdater.h
+++ b/fvupdater.h
@@ -56,7 +56,10 @@ public slots:
 signals:
     // This signal will inform, whether network is accessible or not
     void updatesDownloaded(bool success);
-    void proposedUpdateChanged(FvAvailableUpdate* proposedUpdate);
+    // void proposedUpdateChanged(FvAvailableUpdate* proposedUpdate);
+    void proposedVersionChanged(QString version);
+    void proposedReleaseNotesChanged(QString content);
+    void proposedReleaseNotesLinkChanged(QUrl link);
     void updateDownloadLinkReady(QString link);
 
 


### PR DESCRIPTION
This PR introduces QUIET and NORMAL modes of operation for fervor backend. 

 - In QUIET mode fervor only sends signals with the proposed update object or the download link.
 - In NORMAL mode the stock QWidget implementation of the dialogs is used.